### PR TITLE
get_local needs file:// scheme, not file:/ scheme

### DIFF
--- a/lib/WWW/Mechanize/PhantomJS.pm
+++ b/lib/WWW/Mechanize/PhantomJS.pm
@@ -420,7 +420,7 @@ sub get_local {
                  Cwd::getcwd(),
              );
     $fn =~ s!\\!/!g; # fakey "make file:// URL"
-    my $url= "file:/$fn";
+    my $url= "file://$fn";
 
     my $res= $self->get($url, %options);
 


### PR DESCRIPTION
the CPAN version won't install because of broken test suite.

Based on my investigation: an absolute path (say "/etc/passwd") would be noted as
file:///etc/passwd. for now it's file://etc/passwd.
