### PR TITLE
Disable session specific cookiejar

### DIFF
--- a/lib/WWW/Mechanize/PhantomJS/ghostdriver/session.js
+++ b/lib/WWW/Mechanize/PhantomJS/ghostdriver/session.js
@@ -413,7 +413,7 @@ ghostdriver.Session = function(desiredCapabilities) {
         // decorate the new Window/Page
         newPage = _decorateNewWindow(newPage);
         // set session-specific CookieJar
-        newPage.cookieJar = _cookieJar;
+        // newPage.cookieJar = _cookieJar;
         // store the Window/Page by WindowHandle
         _windows[newPage.windowHandle] = newPage;
     },
@@ -657,7 +657,7 @@ ghostdriver.Session = function(desiredCapabilities) {
             // Decorate it with listeners and helpers
             page = _decorateNewWindow(page);
             // set session-specific CookieJar
-            page.cookieJar = _cookieJar;
+            // page.cookieJar = _cookieJar;
             // Make the new Window, the Current Window
             _currentWindowHandle = page.windowHandle;
             // Store by WindowHandle
@@ -789,7 +789,7 @@ ghostdriver.Session = function(desiredCapabilities) {
         }
 
         // Release CookieJar resources
-        _cookieJar.close();
+        // _cookieJar.close();
     },
 
     _getLog = function (type) {

--- a/t/99-cookie_file.t
+++ b/t/99-cookie_file.t
@@ -1,0 +1,12 @@
+#!perl -w
+use strict;
+use Test::More tests => 1;
+use File::Temp;
+use WWW::Mechanize::PhantomJS;
+
+my $tmp = File::Temp->new;
+my $mech = WWW::Mechanize::PhantomJS->new( 
+    cookie_file => $tmp->filename,
+);
+$mech->get_local('99-cookie_file.html');
+ok -s $tmp->filename > 0, "cookie_file saved.";


### PR DESCRIPTION
This is a continuation of #18

cookie_file saving is now working.

If you implement cookies per session according to https://github.com/detro/ghostdriver/issues/170 , it might be like the following.

<pre>
# lib/WWW/Mechanize/PhantomJS.pm:222
$options{ driver } ||= Selenium::Remote::Driver->new(
    extra_capabilities => { cookieFile => $file },
    ...

# lib/WWW/Mechanize/PhantomJS/ghostdriver/session.js:116
_cookieJar = require('cookiejar').create( desiredCapabilities['cookieFile'] ),
</pre>

But since Selenium::Remote::Driver launches phantomjs for each instance, it may not be necessary to use cookies per session.

Thank you for your time.
